### PR TITLE
feat Nat command

### DIFF
--- a/src/commands/fun/nat.ts
+++ b/src/commands/fun/nat.ts
@@ -1,0 +1,35 @@
+//============================================================
+//
+// Salty Simulations Discord Bot
+// Author: saltysimulations
+// URL: https://github.com/owen2007/Salty-Simulations-Discord-Bot/
+// Date: 2022-04-25
+// Version: 0.0.1
+// License: AGPLv3
+//
+// Source based on:
+// FlyByWire Discord Bot
+// Author: flybywire
+// URL: https://github.com/flybywiresim/discord-bot/
+//
+//============================================================
+//
+// NAT
+//
+//============================================================
+
+import { makeEmbed } from '../../lib/embed';
+
+const NAT_URL: string = "https://cdn.discordapp.com/attachments/987508579508572201/987509878874603520/anime-cute.gif";
+
+const nat = {
+    id: 'nat', // Unique command identifier
+    name: ['nat', 'ninjo'],
+    description: 'nat command',
+    run: async (client, message, args) => {
+        const natEmbed = makeEmbed({ image: { url: NAT_URL }});
+        await message.channel.send({ embeds: [ natEmbed ] });
+    }
+};
+
+export const command = nat;


### PR DESCRIPTION
# Description

adds the Nat command to the salty simulations discord bot

# Images

![image](https://user-images.githubusercontent.com/100061049/174414684-91091453-d574-4e67-b302-4b3418bf6616.png)
![image](https://user-images.githubusercontent.com/100061049/174414697-10afe5a3-7036-47cd-8339-d6815a8e6695.png)

# Aliases 

include (nat, ninjo)

# Discord username

owen_ #4883